### PR TITLE
[AWIBOF-6845] added lock for versioned segment info.

### DIFF
--- a/src/journal_manager/log_buffer/versioned_segment_info.cpp
+++ b/src/journal_manager/log_buffer/versioned_segment_info.cpp
@@ -38,48 +38,65 @@ namespace pos
 {
 VersionedSegmentInfo::VersionedSegmentInfo(void)
 {
+    pthread_rwlock_init(&lock, nullptr);
 }
 
 VersionedSegmentInfo::~VersionedSegmentInfo(void)
 {
     changedValidBlockCount.clear();
     changedOccupiedStripeCount.clear();
+
+    pthread_rwlock_destroy(&lock);
 }
 
 void
 VersionedSegmentInfo::Reset(void)
 {
+    pthread_rwlock_wrlock(&lock);
     changedOccupiedStripeCount.clear();
     changedValidBlockCount.clear();
+    pthread_rwlock_unlock(&lock);
 }
 
 void
 VersionedSegmentInfo::IncreaseValidBlockCount(SegmentId segId, uint32_t cnt)
 {
+    pthread_rwlock_wrlock(&lock);
     changedValidBlockCount[segId] += cnt;
+    pthread_rwlock_unlock(&lock);
 }
 
 void
 VersionedSegmentInfo::DecreaseValidBlockCount(SegmentId segId, uint32_t cnt)
 {
+    pthread_rwlock_wrlock(&lock);
     changedValidBlockCount[segId] -= cnt;
+    pthread_rwlock_unlock(&lock);
 }
 
 void
 VersionedSegmentInfo::IncreaseOccupiedStripeCount(SegmentId segId)
 {
+    pthread_rwlock_wrlock(&lock);
     changedOccupiedStripeCount[segId]++;
+    pthread_rwlock_unlock(&lock);
 }
 
 std::unordered_map<SegmentId, int>
 VersionedSegmentInfo::GetChangedValidBlockCount(void)
 {
-    return this->changedValidBlockCount;
+    pthread_rwlock_rdlock(&lock);
+    auto var = this->changedValidBlockCount;
+    pthread_rwlock_unlock(&lock);
+    return var;
 }
 
 std::unordered_map<SegmentId, uint32_t>
 VersionedSegmentInfo::GetChangedOccupiedStripeCount(void)
 {
-    return this->changedOccupiedStripeCount;
+    pthread_rwlock_rdlock(&lock);
+    auto var = this->changedOccupiedStripeCount;
+    pthread_rwlock_unlock(&lock);
+    return var;
 }
 } // namespace pos

--- a/src/journal_manager/log_buffer/versioned_segment_info.h
+++ b/src/journal_manager/log_buffer/versioned_segment_info.h
@@ -56,6 +56,7 @@ public:
 private:
     std::unordered_map<SegmentId, int> changedValidBlockCount;
     std::unordered_map<SegmentId, uint32_t> changedOccupiedStripeCount;
+    pthread_rwlock_t lock;
 };
 
 } // namespace pos


### PR DESCRIPTION
Code changes:
added lock before reset, get values from versioned segment info.

Signed-off-by: dh.ihm <dh.ihm@samsung.com>